### PR TITLE
ci: fix Github Action workflow (ansible-lint step)

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install ansible yamllint ansible-lint==5.0.1
+          pip3 install ansible yamllint ansible-lint
 
       - name: Lint code.
         run: |

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -8,7 +8,8 @@
     - "reboot windows node"
 
 # NOTE: ansible will wait for the node to come back up again
-- meta: flush_handlers
+- name: Win Docker | Reboot node if Windows Features got installed
+  meta: flush_handlers
 
 - name: Win Docker | Configure RoutingOnly
   win_shell: Install-RemoteAccess -VpnType RoutingOnly
@@ -29,7 +30,7 @@
 - name: Win Docker | Test if Docker needs install
   win_shell: docker version
   register: docker_command
-  ignore_errors: true
+  failed_when: false
 
 - name: Win Docker | Install Docker
   win_shell: Install-Package -Name docker -ProviderName DockerMsftProvider -Force


### PR DESCRIPTION
- Unfreeze ansible-lint version: 5.0.1 -> 5.0.11 (latest)
- Adapt role to new ansible lint rules